### PR TITLE
Fix WordCloud stoplist and document summary endpoint

### DIFF
--- a/core-components/algo/new_algo_template/backend/app.py
+++ b/core-components/algo/new_algo_template/backend/app.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from collections import Counter
+import nltk
+from nltk.tokenize import sent_tokenize
 
 # Import utility functions
 from utils.text_processing import extract, cleansing
@@ -375,7 +377,16 @@ def get_document_summary():
         vocabulary_density = unique_words / total_words if total_words > 0 else 0
         
         # Calculate readability (simple implementation)
-        total_sentences = df['clean_text'].str.count('[.!?]+').sum()
+        # Ensure NLTK data is downloaded
+        try:
+            nltk.data.find('tokenizers/punkt')
+        except LookupError:
+            print("Downloading NLTK punkt data...")
+            nltk.download('punkt')
+        
+        # Count sentences from masked_text
+        all_text = ' '.join(df['masked_text'].dropna().astype(str))
+        total_sentences = len(sent_tokenize(all_text))
         words_per_sentence = total_words / total_sentences if total_sentences > 0 else 0
         avg_word_length = sum(len(word) for word in all_words) / len(all_words) if all_words else 0
         readability_index = 0.4 * (words_per_sentence + 100 * (len([w for w in all_words if len(w) > 6]) / total_words))

--- a/core-components/algo/new_algo_template/frontend/src/components/WordCloud/store.ts
+++ b/core-components/algo/new_algo_template/frontend/src/components/WordCloud/store.ts
@@ -469,7 +469,9 @@ export const useWordCloudStore = create<WordCloudStore>((set, get) => ({
         shouldUpdateLayout: true,
         isWhitelistModalOpen: false,
         modalsOpen: false,
-        isWordSelectionAction: false // Ensure this is not treated as a word selection
+        isWordSelectionAction: false, // Ensure this is not treated as a word selection
+        // Force a complete refiltering by invalidating the cache
+        filterCacheKey: String(Date.now())
       });
       
       // Save to localStorage
@@ -586,6 +588,12 @@ export const useWordCloudStore = create<WordCloudStore>((set, get) => ({
     
     // Save to localStorage
     localStorage.setItem(STORAGE_KEYS.WHITELIST_ACTIVE, newWhitelistActive ? 'true' : 'false');
+    
+    // Always force filteredWords to be recomputed completely
+    // This ensures the visualization updates properly when no words match the whitelist
+    set({
+      filterCacheKey: String(Date.now()) // Invalidate filter cache
+    });
     
     // Handle search term separately if needed
     if (searchTerm) {
@@ -725,9 +733,17 @@ export const useWordCloudStore = create<WordCloudStore>((set, get) => ({
     
     // Apply whitelist if active
     if (state.whitelistActive && whitelist.length > 0) {
-      filtered = filtered.filter((word) => 
+      const whitelistFiltered = filtered.filter((word) => 
         whitelist.includes(word.value.toLowerCase())
       );
+      
+      // If whitelist is active but no words match, we should show an empty set
+      filtered = whitelistFiltered;
+      
+      // Force a layout update if filtering resulted in empty set
+      if (filtered.length === 0) {
+        set({ shouldUpdateLayout: true });
+      }
     }
     
     // Apply stoplist if active


### PR DESCRIPTION
This PR addresses two issues:

## WordCloud fixes
- Fixed an issue where the word cloud wasn't properly clearing when the whitelist contained no matching words
- Added cache invalidation when toggling whitelist state to ensure fresh data
- Implemented forced layout updates when whitelist filtering returns empty results

## Document summary improvements
- Fixed the document summary endpoint by integrating NLTK for proper sentence tokenization
- Updated sentence counting logic to utilize tokenized sentences from masked text
- Ensures accurate document statistics throughout the processing pipeline

These changes improve the reliability of the word cloud component when filtering and enhance the accuracy of the document summary functionality.